### PR TITLE
bump mysql connector to new version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,9 +102,9 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.27</version>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.4.0</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
this is an ancient mysql connector which has some issues. Mysql has moved its connector location in maven to a new place. 

I can't get tests to work locally... since just jdbc, I guess this is fine??