### PR TITLE
Bump Spark to 3.5.7 to fix CVE-2025-54920

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven.version>3.6.3</maven.version>
     <scala.version>2.12.8</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>3.5.0</spark.version>
+    <spark.version>3.5.7</spark.version>
     <iceberg.version>1.4.2</iceberg.version>
     <snappy-java.version>1.1.8.2</snappy-java.version>
 


### PR DESCRIPTION
## Summary

Dependabot flagged a high-severity RCE in our Spark 3.5.0 dependency (CVE-2025-54920 / GHSA-jwp6-cvj8-fw65). The Spark History Server deserializes event log JSON with Jackson polymorphic typing enabled, which lets anyone with write access to the events directory instantiate arbitrary classes and trigger code execution. Apache fixed it in 3.5.7, so we bump to pick up the patch.

## What

Single-line change in `pom.xml`: `spark.version` 3.5.0 → 3.5.7. The property cascades to `spark-sql`, `spark-core`, and `spark-hive`, all of which are `provided` scope. No code changes — 3.5.7 is a patch release within the same 3.5.x line.

## Testing

- `mvn -DskipTests package` builds cleanly and produces both the thin jar and the shaded `-with-dependencies` jar.
- `mvn dependency:tree` confirms `spark-core_2.12`, `spark-sql_2.12`, and `spark-hive_2.12` all resolve to 3.5.7.
- No runtime/integration test against an iomete cluster.

## Relevant links

- Dependabot alert: https://github.com/iomete/spark-tpcds-datagen/security/dependabot/9
- Advisory: https://github.com/advisories/GHSA-jwp6-cvj8-fw65
- Apache fix: https://github.com/apache/spark/pull/51312

## Rollout

No special rollout considerations. Spark deps are `provided` scope — the runtime version is whatever the executing Spark cluster supplies, so this only affects compile-time API resolution. 3.5.7 is API-compatible with 3.5.0 within the 3.5.x patch series.